### PR TITLE
fix: handle possible invalid keys and more valid ones

### DIFF
--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import inspect
 import json
 import re
 
@@ -12,13 +13,43 @@ logger = logging.getLogger(__name__)
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, BaseSettings):
-            return dict(obj)
+            return CustomEncoder.clean_settings_dict(dict(obj))
         if isinstance(obj, set):
             return str(obj)
         return json.JSONEncoder.default(self, obj)
 
+    @classmethod
+    def clean_settings_dict(cls, settings_dict):
+        parsed_settings = {}
+        for key in settings_dict:
+            if (
+                isinstance(key, str) or
+                isinstance(key, int) or
+                isinstance(key, float) or
+                isinstance(key, bool) or
+                key is None
+            ):
+                parsed_settings[key] = CustomEncoder.clean_settings_value(settings_dict[key])
+            elif inspect.isclass(key):
+                parsed_settings[key.__name__] = CustomEncoder.clean_settings_value(settings_dict[key])
+            elif isinstance(key, tuple):
+                parsed_settings[str(key)] = CustomEncoder.clean_settings_value(settings_dict[key])
+            else:
+                # Warn that key is of unexpected type. ex: a class object.
+                parsed_settings[str(key)] = CustomEncoder.clean_settings_value(settings_dict[key])
+                logger.warn(f"Using __str__ for {key} as it cannot be encoded as JSON.")
+        return parsed_settings
+
+    @classmethod
+    def clean_settings_value(cls, value):
+        if isinstance(value, BaseSettings) or isinstance(value, dict):
+            return CustomEncoder.clean_settings_dict(value)
+        return value
+
 
 class SpiderSettingsLogging:
+    custom_encoder = CustomEncoder
+
     @classmethod
     def from_crawler(cls, crawler):
         ext = cls()
@@ -39,4 +70,5 @@ class SpiderSettingsLogging:
     def output_settings(self, settings: dict, spider: scrapy.Spider):
         # this can be overwritten in a subclass if you want to send this data elsewhere
         indent = spider.settings.get("SETTINGS_LOGGING_INDENT")
-        logger.info(json.dumps(settings, indent=indent, cls=CustomEncoder))
+        clean_settings = self.custom_encoder.clean_settings_dict(settings)
+        logger.info(json.dumps(clean_settings, indent=indent, cls=self.custom_encoder))


### PR DESCRIPTION
In some instances, the scrapy-settings-log extension can cause an error. For example, when the settings contain a class instance as a key, or a custom class.

This PR will attempt a "reasonable effort basis" conversion from these data types, while doing default conversion on unexpected values.