### PR TITLE
adding settings options with regex to be able to mask sensitive data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ When you run your spider you will see a log like below when spider is closing:
 
 * `SETTINGS_LOGGING_REGEX` - Add a regular expression to only show some settings - for example `SETTINGS_LOGGING_REGEX = "SPIDERMON"` will show settings with SPIDERMON in their name.
 * `SETTINGS_LOGGING_INDENT` - Add indentation to make log more human-readable.
+* `MASKED_SENSITIVE_SETTINGS_ENABLED` - Default is `True` - if settings logging is enabled it will mask the value of settings that may be sensitive (password, apikey). For example AWS_SECRET_ACCESS_KEY will have their value shown as **********
 
 ## Advanced
 

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -59,7 +59,7 @@ class SpiderSettingsLogging:
             ]
             regex_list = settings.get("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
             for reg in regex_list:
-                updated_settings = {k: '*'*len(v) if v else v for k, v in settings.items() if re.match(reg, k)}
+                updated_settings = {k: '**********' if v else v for k, v in settings.items() if re.match(reg, k)}
                 settings = {**settings, **updated_settings}
 
         self.output_settings(settings, spider)

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -58,7 +58,7 @@ class SpiderSettingsLogging:
             ]
             regex_list = settings.get("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
             for reg in regex_list:
-                updated_settings = {k: '*'*len(v) for k, v in settings.items() if re.match(reg, k)}
+                updated_settings = {k: '*'*len(v) for k, v in settings.items() if re.search(reg, k)}
                 settings = {**settings, **updated_settings}
 
         self.output_settings(settings, spider)

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -51,11 +51,11 @@ class SpiderSettingsLogging:
         regex = settings.get("SETTINGS_LOGGING_REGEX")
         if regex is not None:
             settings = {k: v for k, v in settings.items() if re.search(regex, k)}
-        default_regexes = [
-            "(?i)(api[\W_]*key)",  # apikey and possible variations
-            "(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY)"  # AWS_SECRET_ACCESS_KEY and possible variations
-        ]
         if settings.get("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
+            default_regexes = [
+                "(?i)(api[\W_]*key)",  # apikey and possible variations
+                "(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY)"  # AWS_SECRET_ACCESS_KEY and possible variations
+            ]
             regex_list = settings.get("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
             for reg in regex_list:
                 updated_settings = {k: '*'*len(v) for k, v in settings.items() if re.match(reg, k)}

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -51,6 +51,15 @@ class SpiderSettingsLogging:
         regex = settings.get("SETTINGS_LOGGING_REGEX")
         if regex is not None:
             settings = {k: v for k, v in settings.items() if re.search(regex, k)}
+        default_regexes = [
+            "(?i)(api[\W_]*key)",  # apikey and possible variations
+            "(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY)"  # AWS_SECRET_ACCESS_KEY and possible variations
+        ]
+        if settings.get("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
+            regex_list = settings.get("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
+            for reg in regex_list:
+                updated_settings = {k: '*'*len(v) for k, v in settings.items() if re.match(reg, k)}
+                settings = {**settings, **updated_settings}
 
         self.output_settings(settings, spider)
 

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -53,12 +53,13 @@ class SpiderSettingsLogging:
             settings = {k: v for k, v in settings.items() if re.search(regex, k)}
         if settings.get("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
             default_regexes = [
-                "(?i)(api[\W_]*key)",  # apikey and possible variations
-                "(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY)"  # AWS_SECRET_ACCESS_KEY and possible variations
+                ".*(?i)(api[\W_]*key).*",  # apikey and possible variations e.g: shub_apikey or SC_APIKEY
+                ".*(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY).*",  # AWS_SECRET_ACCESS_KEY and possible variations
+                ".*(?i)([\W_]*password[\W_]*).*"  # password word
             ]
             regex_list = settings.get("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
             for reg in regex_list:
-                updated_settings = {k: '*'*len(v) for k, v in settings.items() if re.search(reg, k)}
+                updated_settings = {k: '*'*len(v) if v else v for k, v in settings.items() if re.match(reg, k)}
                 settings = {**settings, **updated_settings}
 
         self.output_settings(settings, spider)

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -51,13 +51,13 @@ class SpiderSettingsLogging:
         regex = settings.get("SETTINGS_LOGGING_REGEX")
         if regex is not None:
             settings = {k: v for k, v in settings.items() if re.search(regex, k)}
-        if settings.get("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
+        if spider.settings.getbool("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
             default_regexes = [
                 ".*(?i)(api[\W_]*key).*",  # apikey and possible variations e.g: shub_apikey or SC_APIKEY
                 ".*(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY).*",  # AWS_SECRET_ACCESS_KEY and possible variations
                 ".*(?i)([\W_]*password[\W_]*).*"  # password word
             ]
-            regex_list = settings.get("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
+            regex_list = spider.settings.getlist("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
             for reg in regex_list:
                 updated_settings = {k: '**********' if v else v for k, v in settings.items() if re.match(reg, k)}
                 settings = {**settings, **updated_settings}

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -54,7 +54,7 @@ class SpiderSettingsLogging:
         if spider.settings.getbool("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
             default_regexes = [
                 ".*(?i)(api[\W_]*key).*",  # apikey and possible variations e.g: shub_apikey or SC_APIKEY
-                ".*(?i)(AWS[\W_]*(SECRET[\W_]*)?ACCESS[\W_]*KEY).*",  # AWS_SECRET_ACCESS_KEY and possible variations
+                ".*(?i)(AWS[\W_]*(SECRET[\W_]*)?(ACCESS)?[\W_]*(KEY|ACCESS[\W_]*KEY))",  # AWS_SECRET_ACCESS_KEY and possible variations
                 ".*(?i)([\W_]*password[\W_]*).*"  # password word
             ]
             regex_list = spider.settings.getlist("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -9,6 +9,12 @@ from scrapy import signals
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_REGEXES = [
+    ".*(?i)(api[\W_]*key).*",  # apikey and variations e.g: shub_apikey or SC_APIKEY
+    ".*(?i)(AWS[\W_]*(SECRET[\W_]*)?(ACCESS)?[\W_]*(KEY|ACCESS[\W_]*KEY))",  # AWS_SECRET_ACCESS_KEY and variations
+    ".*(?i)([\W_]*password[\W_]*).*"  # password word
+]
+
 
 def prepare_for_json_serialization(obj):
     """Prepare the obj recursively for JSON serialization.
@@ -52,12 +58,7 @@ class SpiderSettingsLogging:
         if regex is not None:
             settings = {k: v for k, v in settings.items() if re.search(regex, k)}
         if spider.settings.getbool("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
-            default_regexes = [
-                ".*(?i)(api[\W_]*key).*",  # apikey and possible variations e.g: shub_apikey or SC_APIKEY
-                ".*(?i)(AWS[\W_]*(SECRET[\W_]*)?(ACCESS)?[\W_]*(KEY|ACCESS[\W_]*KEY))",  # AWS_SECRET_ACCESS_KEY and possible variations
-                ".*(?i)([\W_]*password[\W_]*).*"  # password word
-            ]
-            regex_list = spider.settings.getlist("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)
+            regex_list = spider.settings.getlist("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", DEFAULT_REGEXES)
             for reg in regex_list:
                 updated_settings = {k: '**********' if v else v for k, v in settings.items() if re.match(reg, k)}
                 settings = {**settings, **updated_settings}

--- a/src/scrapy_settings_log/__init__.py
+++ b/src/scrapy_settings_log/__init__.py
@@ -54,7 +54,7 @@ class SpiderSettingsLogging:
         if spider.settings.getbool("MASKED_SENSITIVE_SETTINGS_ENABLED", True):
             default_regexes = [
                 ".*(?i)(api[\W_]*key).*",  # apikey and possible variations e.g: shub_apikey or SC_APIKEY
-                ".*(?i)(AWS[\W_]*SECRET[\W_]*ACCESS[\W_]*KEY).*",  # AWS_SECRET_ACCESS_KEY and possible variations
+                ".*(?i)(AWS[\W_]*(SECRET[\W_]*)?ACCESS[\W_]*KEY).*",  # AWS_SECRET_ACCESS_KEY and possible variations
                 ".*(?i)([\W_]*password[\W_]*).*"  # password word
             ]
             regex_list = spider.settings.getlist("MASKED_SENSITIVE_SETTINGS_REGEX_LIST", default_regexes)

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -156,6 +156,23 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
     assert 'secret_value' not in caplog.text
 
 
+def test_log_all_should_not_return_password_value_by_default(caplog):
+    settings = {
+        "SETTINGS_LOGGING_ENABLED": True,
+        "test_password": 'secret_value1',
+        "PASSWORD_TEST": 'secret_value2',
+    }
+
+    spider = MockSpider(settings)
+    logger = SpiderSettingsLogging()
+    with caplog.at_level(logging.INFO):
+        logger.spider_closed(spider)
+
+    assert '"test_password": "*************"' in caplog.text
+    assert '"PASSWORD_TEST": "*************"' in caplog.text
+    assert 'secret_value' not in caplog.text
+
+
 def test_log_all_should_return_only_the_custom_regex_data_masked_if_MASKED_SENSITIVE_SETTINGS_REGEX_LIST_configured(caplog):
     settings = {
         "SETTINGS_LOGGING_ENABLED": True,

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -118,8 +118,6 @@ def test_log_all_should_not_return_apikey_value_by_default(caplog):
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    # won't check specifics here as the default settings
-    # can vary with scrapy versions - presence is enough
     assert '"APIKEY": "*************"' in caplog.text
     assert '"apikey": "*************"' in caplog.text
     assert '"api_key": "*************"' in caplog.text
@@ -138,8 +136,6 @@ def test_log_all_should_return_apikey_value_if_MASKED_SENSITIVE_SETTINGS_ENABLED
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    # won't check specifics here as the default settings
-    # can vary with scrapy versions - presence is enough
     assert '"APIKEY": "apikey_value"' in caplog.text
 
 
@@ -155,8 +151,24 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    # won't check specifics here as the default settings
-    # can vary with scrapy versions - presence is enough
     assert '"AWS_SECRET_ACCESS_KEY": "*************"' in caplog.text
     assert '"aws_secret_access_key": "*************"' in caplog.text
     assert 'secret_value' not in caplog.text
+
+
+def test_log_all_should_return_only_the_custom_regex_data_masked_if_MASKED_SENSITIVE_SETTINGS_REGEX_LIST_configured(caplog):
+    settings = {
+        "SETTINGS_LOGGING_ENABLED": True,
+        "MASKED_SENSITIVE_SETTINGS_REGEX_LIST": ["apppppppikey"],
+        "APIKEY": 'apikey_value1',
+        "apppppppikey": 'some_random_value',
+    }
+
+    spider = MockSpider(settings)
+    logger = SpiderSettingsLogging()
+    with caplog.at_level(logging.INFO):
+        logger.spider_closed(spider)
+
+    assert 'apikey_value1' in caplog.text
+    assert '"apppppppikey": "*****************"' in caplog.text
+    assert 'some_random_value' not in caplog.text

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -145,6 +145,8 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
         "AWS_SECRET_ACCESS_KEY": 'secret_value1',
         "aws_secret_access_key": 'secret_value2',
         "aws_access_key": 'secret_value2',
+        "AWS_SECRET_KEY": 'secret_value2',
+        "aws_secret_key": 'secret_value2',
     }
 
     spider = MockSpider(settings)
@@ -155,6 +157,8 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
     assert '"AWS_SECRET_ACCESS_KEY": "**********"' in caplog.text
     assert '"aws_secret_access_key": "**********"' in caplog.text
     assert '"aws_access_key": "**********"' in caplog.text
+    assert '"AWS_SECRET_KEY": "**********"' in caplog.text
+    assert '"aws_secret_key": "**********"' in caplog.text
     assert 'secret_value' not in caplog.text
 
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -103,3 +103,60 @@ def test_log_custom_class(caplog):
         logger.spider_closed(spider)
 
     assert '{"DUMMY_CUSTOM_CLASS": {"CustomClass": "/foo/bar"}}' in caplog.text
+
+
+def test_log_all_should_not_return_apikey_value_by_default(caplog):
+    settings = {
+        "SETTINGS_LOGGING_ENABLED": True,
+        "APIKEY": 'apikey_value1',
+        "apikey": 'apikey_value2',
+        "api_key": 'apikey_value3',
+    }
+
+    spider = MockSpider(settings)
+    logger = SpiderSettingsLogging()
+    with caplog.at_level(logging.INFO):
+        logger.spider_closed(spider)
+
+    # won't check specifics here as the default settings
+    # can vary with scrapy versions - presence is enough
+    assert '"APIKEY": "*************"' in caplog.text
+    assert '"apikey": "*************"' in caplog.text
+    assert '"api_key": "*************"' in caplog.text
+    assert 'apikey_value' not in caplog.text
+
+
+def test_log_all_should_return_apikey_value_if_MASKED_SENSITIVE_SETTINGS_ENABLED_is_false(caplog):
+    settings = {
+        "SETTINGS_LOGGING_ENABLED": True,
+        "APIKEY": 'apikey_value',
+        "MASKED_SENSITIVE_SETTINGS_ENABLED": False,
+    }
+
+    spider = MockSpider(settings)
+    logger = SpiderSettingsLogging()
+    with caplog.at_level(logging.INFO):
+        logger.spider_closed(spider)
+
+    # won't check specifics here as the default settings
+    # can vary with scrapy versions - presence is enough
+    assert '"APIKEY": "apikey_value"' in caplog.text
+
+
+def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
+    settings = {
+        "SETTINGS_LOGGING_ENABLED": True,
+        "AWS_SECRET_ACCESS_KEY": 'secret_value1',
+        "aws_secret_access_key": 'secret_value2',
+    }
+
+    spider = MockSpider(settings)
+    logger = SpiderSettingsLogging()
+    with caplog.at_level(logging.INFO):
+        logger.spider_closed(spider)
+
+    # won't check specifics here as the default settings
+    # can vary with scrapy versions - presence is enough
+    assert '"AWS_SECRET_ACCESS_KEY": "*************"' in caplog.text
+    assert '"aws_secret_access_key": "*************"' in caplog.text
+    assert 'secret_value' not in caplog.text

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -118,9 +118,9 @@ def test_log_all_should_not_return_apikey_value_by_default(caplog):
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    assert '"SHUB_APIKEY": "*************"' in caplog.text
-    assert '"shub_apikey": "*************"' in caplog.text
-    assert '"api_key": "*************"' in caplog.text
+    assert '"SHUB_APIKEY": "**********"' in caplog.text
+    assert '"shub_apikey": "**********"' in caplog.text
+    assert '"api_key": "**********"' in caplog.text
     assert 'apikey_value' not in caplog.text
 
 
@@ -151,8 +151,8 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    assert '"AWS_SECRET_ACCESS_KEY": "*************"' in caplog.text
-    assert '"aws_secret_access_key": "*************"' in caplog.text
+    assert '"AWS_SECRET_ACCESS_KEY": "**********"' in caplog.text
+    assert '"aws_secret_access_key": "**********"' in caplog.text
     assert 'secret_value' not in caplog.text
 
 
@@ -168,8 +168,8 @@ def test_log_all_should_not_return_password_value_by_default(caplog):
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    assert '"test_password": "*************"' in caplog.text
-    assert '"PASSWORD_TEST": "*************"' in caplog.text
+    assert '"test_password": "**********"' in caplog.text
+    assert '"PASSWORD_TEST": "**********"' in caplog.text
     assert 'secret_value' not in caplog.text
 
 
@@ -187,5 +187,5 @@ def test_log_all_should_return_only_the_custom_regex_data_masked_if_MASKED_SENSI
         logger.spider_closed(spider)
 
     assert 'apikey_value1' in caplog.text
-    assert '"apppppppikey": "*****************"' in caplog.text
+    assert '"apppppppikey": "**********"' in caplog.text
     assert 'some_random_value' not in caplog.text

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -144,6 +144,7 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
         "SETTINGS_LOGGING_ENABLED": True,
         "AWS_SECRET_ACCESS_KEY": 'secret_value1',
         "aws_secret_access_key": 'secret_value2',
+        "aws_access_key": 'secret_value2',
     }
 
     spider = MockSpider(settings)
@@ -153,6 +154,7 @@ def test_log_all_should_not_return_aws_secret_key_value_by_default(caplog):
 
     assert '"AWS_SECRET_ACCESS_KEY": "**********"' in caplog.text
     assert '"aws_secret_access_key": "**********"' in caplog.text
+    assert '"aws_access_key": "**********"' in caplog.text
     assert 'secret_value' not in caplog.text
 
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -108,8 +108,8 @@ def test_log_custom_class(caplog):
 def test_log_all_should_not_return_apikey_value_by_default(caplog):
     settings = {
         "SETTINGS_LOGGING_ENABLED": True,
-        "APIKEY": 'apikey_value1',
-        "apikey": 'apikey_value2',
+        "SHUB_APIKEY": 'apikey_value1',
+        "shub_apikey": 'apikey_value2',
         "api_key": 'apikey_value3',
     }
 
@@ -118,8 +118,8 @@ def test_log_all_should_not_return_apikey_value_by_default(caplog):
     with caplog.at_level(logging.INFO):
         logger.spider_closed(spider)
 
-    assert '"APIKEY": "*************"' in caplog.text
-    assert '"apikey": "*************"' in caplog.text
+    assert '"SHUB_APIKEY": "*************"' in caplog.text
+    assert '"shub_apikey": "*************"' in caplog.text
     assert '"api_key": "*************"' in caplog.text
     assert 'apikey_value' not in caplog.text
 


### PR DESCRIPTION
I added the settings MASKED_SENSITIVE_SETTINGS_ENABLED (default true) and MASKED_SENSITIVE_SETTINGS_REGEX_LIST with a default value for apikey, aws_secret_key and password (and multiple variations)
